### PR TITLE
Added initialpreset configurations

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @giantswarm/sig-dev

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 # renovate-presets
+
 A collection of custom Renovate config presets to be used by Giant Swarm repos.
+
+Updates made to these configs will automatically and immediately be made available to all repos that are referencing them. No changes in the individual repos is required as long as they have the reference set up in the `extends` property.
+
+## Usage
+
+To make use of these preset you need to add them to your `extends` array within your repos `renovate.json`.
+
+Multiple presets can be specified and they build on top of each other.
+
+(For full details please refer to the [Renovate docs](https://docs.renovatebot.com/config-presets/#how-to-use-preset-configs)).
+
+The presets found in this repo make use of [JSON5](https://json5.org/) so that comments can be added to make them more maintainable.
+
+### Minimal example
+
+```json
+{
+  "extends": [
+    "github>giantswarm/renovate-presets:default.json5"
+  ],
+}
+```
+
+### Language specific example
+
+```json
+{
+  "extends": [
+    "github>giantswarm/renovate-presets:default.json5",
+    "github>giantswarm/renovate-presets:lang-go.json5"
+  ],
+}
+```
+
+## Resources
+
+* [Shareable config preset](https://docs.renovatebot.com/config-presets/)
+* [Key concepts - Presets](https://docs.renovatebot.com/key-concepts/presets/)

--- a/default.json5
+++ b/default.json5
@@ -1,0 +1,67 @@
+{
+  "extends": [
+    "config:recommended" // https://docs.renovatebot.com/presets-config/#configrecommended
+  ],
+  // The labels to add to the GitHub PRs
+  "labels": ["dependencies", "renovate"],
+  // The dependency dashboard is an issue created in the repo that tracks the
+  // dependencies that Renovate will work againse
+  "dependencyDashboard": true,
+  "assigneesFromCodeOwners": true,
+
+  // These limits are the defaults values but included here for visibility
+  "branchConcurrentLimit": 10,
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 2,
+
+  "ignorePaths": [
+    ".github/workflows/zz_generated.*",
+    ".github/workflows/codeql-analysis.yml",
+    ".github/workflows/pre_commit_*.yaml"
+  ],
+  "ignoreDeps": [
+    "actions/setup-go",
+    "architect",
+    "github.com/imdario/mergo",
+    "zricethezav/gitleaks-action"
+  ],
+
+  // Supports updating both image versions and Kubernetes API versions (e.g. `apiVersion: apps/v1beta1`)
+  "kubernetes": {
+    "fileMatch": ["\\.y[a]?ml$"]
+  }
+
+  "customManagers": [
+    {
+      // Supports various formats where a comment with `repo: ${REPO_NAME}` is on the line
+      // before the version string line
+      "customType": "regex",
+      "fileMatch": [
+        ".*y[a]?ml$",
+        "Dockerfile$",
+        "^Makefile\\..+\\.mk$",
+      ],
+      "matchStrings": [
+        "repo: (?<depName>.*)\n(.+)\\?= v?(?<currentValue>\\S+)\n",
+        "repo: (?<depName>.*)\n(.+)\\/releases\\/download\\/(?<currentValue>.+)\\/.*",
+        "repo: (?<depName>.*)\n(.+)=v?(?<currentValue>\\S+)\n",
+        "repo: (?<depName>.*)\n(.+)VERSION=(?<currentValue>.+)\\/.*",
+        "repo: (?<depName>.*)\n(\\s)*version: (?<currentValue>.*?)\n",
+        "repo: (?<depName>.*)\n(\\s)*version:(\\s)*(?<currentValue>.*?)(\\s)*\n",
+        "repo: (?<depName>.*)\n(\\s*)default: \"?.+:(?<currentValue>.*?)\"?\n",
+      ],
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^\"?v?(?<version>.*)\"?$"
+    },
+    {
+      // Supports matching a version where the datasource and dep name are defined in a comment on the previous line
+      "customType": "regex",
+      "fileMatch": ["^Dockerfile$"],
+      "matchStrings": [
+        "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG .+_VER=(?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ],
+
+}

--- a/disable-ansible.json5
+++ b/disable-ansible.json5
@@ -1,0 +1,3 @@
+{
+  "ansible": { "enabled": false },
+}

--- a/disable-kustomize.json5
+++ b/disable-kustomize.json5
@@ -1,0 +1,3 @@
+{
+  "kustomize": { "enabled": false },
+}

--- a/flux.json5
+++ b/flux.json5
@@ -1,0 +1,8 @@
+{
+  // https://docs.renovatebot.com/modules/manager/flux/
+  "flux": {
+    "fileMatch": [
+      "(?:^|/)gotk-components\\.ya?ml$"
+    ]
+  },
+}

--- a/lang-go.json5
+++ b/lang-go.json5
@@ -1,0 +1,35 @@
+{
+  "packageRules": [
+    {
+      "matchPackagePatterns": [".*giantswarm.*"],
+      "groupName": "giantswarm modules"
+    },
+    {
+      "matchPackagePatterns": ["github.com/onsi/*"],
+      "groupName": "test libraries"
+    },
+    {
+      "matchPackagePatterns": ["^k8s.io"],
+      "groupName": "k8s modules",
+      "allowedVersions": "< 0.21.0"
+    },
+    {
+      "matchPackagePatterns": ["^sigs.k8s.io"],
+      "groupName": "sig k8s modules"
+    },
+    {
+      "matchPackagePatterns": ["^sigs.k8s.io/cluster*"],
+      "groupName": "capi modules",
+      "enabled": false
+    },
+    {
+      "matchPackageNames": ["sigs.k8s.io/controller-runtime"],
+      "allowedVersions": "< 0.7.0"
+    },
+    {
+      "matchPackagePatterns": ["^github.com/giantswarm/apiextensions*"],
+      "allowedVersions": ">= 4.0.0"
+    },
+  ],
+  "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
+}

--- a/lang-python.json5
+++ b/lang-python.json5
@@ -1,0 +1,8 @@
+{
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "automerge": true
+    }
+  ],
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/28267

This PR adds the initial set of presets to be used. These were built based what we have currently produced by `devctl` and combined with a few common overrides that were in use by several repos.

The `default.json5` preset should be the bare minimum that any of our Renovate-enabled repos make use of. This preset extends the default Renovate recommended config (previously called `config:base`) and sets some common ignores and settings. 
In addition the the pre-existing config we have today, this default preset also provides the following:
* Enables the `kubernetes` datasource for all yaml files
* Adds two custom managers that are used by several repos to support matching a dependency version based on a comment (e.g. `# repo: giantswarm/example`)
* Explicitly lists some of the PR/branch limits, using their default values, to make it clear that these limits are in place in case people want to override them for their repo.

The `lang-go.json5` and `lang-python.json5` preset add the package rules for those two programming languages as is supported by our `devctl` template today.

Some extra helper presets are also included:
* `disable-ansible.json5` disables the ansible datasource that often needlessly matches too many files (disabling reduces noise in logs)
* `disable-kustomize.json5` disables the Kustomize datasource
* `flux.json5` enables the Flux datasource for paths within the Flux-standard `gotk-components` directory.