### PR TITLE
Add exclusion rule for flux CRDs

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -64,4 +64,16 @@
     }
   ],
 
+  "packageRules": [
+    {
+      // Avoid Flux related CRD version updates in Go projects
+      // (contact Team Honeybadger for details)
+      "matchPackagePatterns": [
+        "kustomize.toolkit.fluxcd.io/v1",
+        "source.toolkit.fluxcd.io/v1",
+      ],
+      "enabled": false,
+    },
+  ],
+
 }

--- a/lang-go.json5
+++ b/lang-go.json5
@@ -30,15 +30,6 @@
       "matchPackagePatterns": ["^github.com/giantswarm/apiextensions*"],
       "allowedVersions": ">= 4.0.0"
     },
-    {
-      // Avoid Flux related CRD version updates in Go projects
-      // (contact Team Honeybadger for details)
-      "matchPackagePatterns": [
-        "kustomize.toolkit.fluxcd.io/v1",
-        "source.toolkit.fluxcd.io/v1",
-      ],
-      "enabled": false
-    },
   ],
   "postUpdateOptions": [
     "gomodTidy",

--- a/lang-go.json5
+++ b/lang-go.json5
@@ -30,6 +30,18 @@
       "matchPackagePatterns": ["^github.com/giantswarm/apiextensions*"],
       "allowedVersions": ">= 4.0.0"
     },
+    {
+      // Avoid Flux related CRD version updates in Go projects
+      // (contact Team Honeybadger for details)
+      "matchPackagePatterns": [
+        "kustomize.toolkit.fluxcd.io/v1",
+        "source.toolkit.fluxcd.io/v1",
+      ],
+      "enabled": false
+    },
   ],
-  "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodUpdateImportPaths",
+  ],
 }


### PR DESCRIPTION
This attempts to block updates of FluxCD CRD versions used in several repositories.

