### PR TITLE
Update lang-go.json5

### DIFF
--- a/lang-go.json5
+++ b/lang-go.json5
@@ -20,11 +20,6 @@
     {
       "matchPackagePatterns": ["^sigs.k8s.io/cluster*"],
       "groupName": "capi modules",
-      "enabled": false
-    },
-    {
-      "matchPackageNames": ["sigs.k8s.io/controller-runtime"],
-      "allowedVersions": "< 0.7.0"
     },
     {
       "matchPackagePatterns": ["^github.com/giantswarm/apiextensions*"],

--- a/lang-go.json5
+++ b/lang-go.json5
@@ -11,7 +11,6 @@
     {
       "matchPackagePatterns": ["^k8s.io"],
       "groupName": "k8s modules",
-      "allowedVersions": "< 0.21.0"
     },
     {
       "matchPackagePatterns": ["^sigs.k8s.io"],


### PR DESCRIPTION
Based on https://gigantic.slack.com/archives/C2MS2VB37/p1698241665584449

Renovate PRs most likely will break; as upgrading CAPI deps require some code changes. See https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/providers/migrations/v1.3-to-v1.4.md?plain=1#L42