### PR TITLE
Force opsctl to use strict semver versioning

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -26,6 +26,14 @@
     "zricethezav/gitleaks-action"
   ],
 
+  "packageRules": [
+    {
+      // Force `opsctl` to use strict semver to ignore the old sha-based releases from 2018
+      "matchPackageNames": ["giantswarm/opsctl"],
+      "versioning": "semver"
+    },
+  ],
+
   // Supports updating both image versions and Kubernetes API versions (e.g. `apiVersion: apps/v1beta1`)
   "kubernetes": {
     "fileMatch": ["\\.y[a]?ml$"]


### PR DESCRIPTION
Force the `opsctl` package to use strict semver rather than the `semver-coerced` that is the default. This should hopefully prevent Renovate picking up on the old sha-based releases from back in 2018. 

Example: https://github.com/giantswarm/tinkerers-ci/pull/22