### PR TITLE
Auto-merge Go PRs for patch dependency upgrades

### DIFF
--- a/lang-go.json5
+++ b/lang-go.json5
@@ -30,6 +30,13 @@
       "matchPackagePatterns": ["^github.com/giantswarm/apiextensions*"],
       "allowedVersions": ">= 4.0.0"
     },
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+      ],
+      "automerge": true,
+    },
   ],
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
 }

--- a/lang-go.json5
+++ b/lang-go.json5
@@ -32,7 +32,6 @@
     },
     {
       "matchUpdateTypes": [
-        "minor",
         "patch",
       ],
       "automerge": true,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28741

This should reduce human intervention in the cases where dependencies are updated with non-breaking changes.

For the affected Go projects this means: Renovate will merge dependency update PRs automatically once all checks are green.

Please watch your repositories and check whether these safeguards are in place:

- Compilation(at least `go test`) happens during a CI/CD check
- and is required per branch protection rule for the default branch