### PR TITLE
Group AWS SDK dependencies

### DIFF
--- a/lang-go.json5
+++ b/lang-go.json5
@@ -9,6 +9,10 @@
       "groupName": "test libraries"
     },
     {
+      "matchPackagePatterns": ["github.com/aws/aws-sdk-go*"],
+      "groupName": "aws sdk"
+    },
+    {
       "matchPackagePatterns": ["^k8s.io"],
       "groupName": "k8s modules",
       "allowedVersions": "< 0.21.0"


### PR DESCRIPTION
This PR tries to group the AWS SDK dependencies so that they all are upgraded in the same PR to avoid the noise.