### PR TITLE
Support helm_release resources in terraform

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -48,6 +48,7 @@
         ".*y[a]?ml$",
         "Dockerfile$",
         "^Makefile\\..+\\.mk$",
+        ".*\\.tf$",
       ],
       "matchStrings": [
         "repo: (?<depName>.*)\n(.+)\\?= v?(?<currentValue>\\S+)\n",
@@ -56,6 +57,7 @@
         "repo: (?<depName>.*)\n(.+)VERSION=v?(?<currentValue>.+)\\/.*",
         "repo: (?<depName>.*)\n(\\s)*version: v?(?<currentValue>.*?)\n",
         "repo: (?<depName>.*)\n(\\s)*version:(\\s)*v?(?<currentValue>.*?)(\\s)*\n",
+        "repo: (?<depName>.*)\n(\\s)*version\\s*=\\s*"v?(?<currentValue>.*?)".*\n",
         "repo: (?<depName>.*)\n(\\s*)default: \"?.+:v?(?<currentValue>.*?)\"?\n",
       ],
       "datasourceTemplate": "github-releases",


### PR DESCRIPTION
I'm not sure if that will work and how to test it.

I'd like it to match lines like below in `*.tf` files in `teleport-fleet` repo:

```
  # used by renovate
  # repo: giantswarm/cert-manager-app
  version = "3.5.0"
```