### PR TITLE
Update Go package group regex to be more specific

### DIFF
--- a/lang-go.json5
+++ b/lang-go.json5
@@ -1,8 +1,8 @@
 {
   "packageRules": [
     {
-      "matchPackagePatterns": [".*giantswarm.*"],
-      "groupName": "giantswarm modules"
+      "matchPackagePatterns": ["^github.com/giantswarm.*"],
+      "groupName": "Giant Swarm Go modules"
     },
     {
       "matchPackagePatterns": ["github.com/onsi/*"],

--- a/lang-go.json5
+++ b/lang-go.json5
@@ -3,7 +3,7 @@
     {
       "matchPackagePatterns": [".*giantswarm.*"],
       "groupName": "Giant Swarm Go modules",
-      matchManagers": ["gomod"]
+      "matchManagers": ["gomod"]
     },
     {
       "matchPackagePatterns": ["github.com/onsi/*"],

--- a/lang-go.json5
+++ b/lang-go.json5
@@ -1,8 +1,9 @@
 {
   "packageRules": [
     {
-      "matchPackagePatterns": ["^github.com/giantswarm.*"],
-      "groupName": "Giant Swarm Go modules"
+      "matchPackagePatterns": [".*giantswarm.*"],
+      "groupName": "Giant Swarm Go modules",
+      matchManagers": ["gomod"]
     },
     {
       "matchPackagePatterns": ["github.com/onsi/*"],


### PR DESCRIPTION
Currently the giantswarm grouping includes Docker images, like `quay.io/giantswarm/alpine`.

Example: https://github.com/giantswarm/app-operator/pull/1186

This PR makes the matching rule more specific to avoid that.