### PR TITLE
Add support for -debug tagged container images.

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -66,7 +66,6 @@
         "repo: (?<depName>.*)\n(\\s)*version: v?(?<currentValue>.*?)\n",
         "repo: (?<depName>.*)\n(\\s)*version:(\\s)*v?(?<currentValue>.*?)(\\s)*\n",
         "repo: (?<depName>.*)\n(\\s*)default: \"?.+:v?(?<currentValue>.*?)(-debug)?\"?\n",
-        "repo: (?<depName>.*)\n(\\s*)default: \"?.+:v?(?<currentValue>.*?)\"?\n",
         "repo: (?<depName>.*)\n(\\s*)image: \"?.+:v?(?<currentValue>.*?)\"?\n",
         "repo: (?<depName>.*)\n(\\s)*([\\w|_]+)release:(\\s)*v?(?<currentValue>.*?)(\\s)*\n",
       ],

--- a/default.json5
+++ b/default.json5
@@ -65,6 +65,7 @@
         "repo: (?<depName>.*)\n(.+)VERSION=v?(?<currentValue>.+)\\/.*",
         "repo: (?<depName>.*)\n(\\s)*version: v?(?<currentValue>.*?)\n",
         "repo: (?<depName>.*)\n(\\s)*version:(\\s)*v?(?<currentValue>.*?)(\\s)*\n",
+        "repo: (?<depName>.*)\n(\\s*)default: \"?.+:v?(?<currentValue>.*?)\"?-debug\n",
         "repo: (?<depName>.*)\n(\\s*)default: \"?.+:v?(?<currentValue>.*?)\"?\n",
         "repo: (?<depName>.*)\n(\\s*)image: \"?.+:v?(?<currentValue>.*?)\"?\n",
         "repo: (?<depName>.*)\n(\\s)*([\\w|_]+)release:(\\s)*v?(?<currentValue>.*?)(\\s)*\n",

--- a/default.json5
+++ b/default.json5
@@ -65,7 +65,7 @@
         "repo: (?<depName>.*)\n(.+)VERSION=v?(?<currentValue>.+)\\/.*",
         "repo: (?<depName>.*)\n(\\s)*version: v?(?<currentValue>.*?)\n",
         "repo: (?<depName>.*)\n(\\s)*version:(\\s)*v?(?<currentValue>.*?)(\\s)*\n",
-        "repo: (?<depName>.*)\n(\\s*)default: \"?.+:v?(?<currentValue>.*?)\"?-debug\n",
+        "repo: (?<depName>.*)\n(\\s*)default: \"?.+:v?(?<currentValue>.*?)(-debug)?\"?\n",
         "repo: (?<depName>.*)\n(\\s*)default: \"?.+:v?(?<currentValue>.*?)\"?\n",
         "repo: (?<depName>.*)\n(\\s*)image: \"?.+:v?(?<currentValue>.*?)\"?\n",
         "repo: (?<depName>.*)\n(\\s)*([\\w|_]+)release:(\\s)*v?(?<currentValue>.*?)(\\s)*\n",


### PR DESCRIPTION
Issue: https://github.com/giantswarm/giantswarm/issues/29964
This change supports the case where the image name is `default: gcr.io/kaniko-project/executor:v1.18.0-debug`. 