### PR TITLE
Adds ignoreUnstable for apps that use prereleases

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -41,6 +41,11 @@
       "matchPackageNames": ["amazon/aws-cli"],
       "sourceUrl": "https://github.com/aws/aws-cli",
     },
+    {
+      // Allow Renovate to use prereleases for apps that use them
+      "matchPackageNames": ["aws-cloud-controller-manager-app"],
+      "ignoreUnstable": "false",
+    },
   ],
 
   // Supports updating both image versions and Kubernetes API versions (e.g. `apiVersion: apps/v1beta1`)


### PR DESCRIPTION
See https://gigantic.slack.com/archives/C0251MXL5/p1715784359506889

tl;dr - apps that use prereleases (i.e: x.x.x-xxx, the after the dash part) don't get updated without ignoreUnstable, so this allows us to specify apps that use them to opt in