### PR TITLE
Prevent updating HelmRelease from helm.toolkit.fluxcd.io/v2beta1, ImageUpdateAutomation from image.toolkit.fluxcd.io/v1beta1

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -41,6 +41,12 @@
       "matchPackageNames": ["amazon/aws-cli"],
       "sourceUrl": "https://github.com/aws/aws-cli",
     },
+    {
+      // Prevent updating HelmRelease from helm.toolkit.fluxcd.io/v2beta1
+      // since we are using Flux 2.1
+      "matchPackageNames": ["HelmRelease"],
+      "allowedVersions":  "helm.toolkit.fluxcd.io/v2beta1",
+    },
   ],
 
   // Supports updating both image versions and Kubernetes API versions (e.g. `apiVersion: apps/v1beta1`)

--- a/default.json5
+++ b/default.json5
@@ -47,6 +47,12 @@
       "matchPackageNames": ["HelmRelease"],
       "allowedVersions":  "helm.toolkit.fluxcd.io/v2beta1",
     },
+    {
+      // Prevent updating ImageUpdateAutomation from image.toolkit.fluxcd.io/v1beta1
+      // since we are using Flux 2.1
+      "matchPackageNames": ["ImageUpdateAutomation"],
+      "allowedVersions":  "image.toolkit.fluxcd.io/v1beta1",
+    },
   ],
 
   // Supports updating both image versions and Kubernetes API versions (e.g. `apiVersion: apps/v1beta1`)


### PR DESCRIPTION
We are currently stuck with Flux v2.1.x and cannot upgrade HelmRelease resources to the latest `helm.toolkit.fluxcd.io/v2` yet.

Same for ImageUpdateAutomation and `image.toolkit.fluxcd.io/v1beta1`

Got the package name and version name from the logs:

![image](https://github.com/giantswarm/renovate-presets/assets/273727/5cfd7081-fefb-499c-88b3-ecf224ea6e67)

