### PR TITLE
Switch from `matchPackage*` to `matchDep*`

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -27,36 +27,36 @@
 
   "packageRules": [
     {
-      // Force `opsctl` to use strict semver to ignore the old sha-based releases from 2018
-      "matchPackageNames": ["giantswarm/opsctl"],
+      // Force opsctl to use strict semver to ignore the old sha-based releases from 2018
+      "matchDepNames": ["giantswarm/opsctl"],
       "versioning": "semver"
     },
     {
       // Allow Renovate to lookup the changelog for architect-orb updates
-      "packageNames": ["architect"],
+      "matchDepNames": ["architect"],
       "sourceUrl": "https://github.com/giantswarm/architect-orb/"
     },
     {
       // Allow renovate to lookup the changelog for aws-cli
-      "matchPackageNames": ["amazon/aws-cli"],
+      "matchDepNames": ["amazon/aws-cli"],
       "sourceUrl": "https://github.com/aws/aws-cli",
     },
     {
       // Prevent updating HelmRelease from helm.toolkit.fluxcd.io/v2beta1
       // since we are using Flux 2.1
-      "matchPackageNames": ["HelmRelease"],
+      "matchDepNames": ["HelmRelease"],
       "allowedVersions":  "helm.toolkit.fluxcd.io/v2beta1",
     },
     {
       // Prevent updating ImageUpdateAutomation from image.toolkit.fluxcd.io/v1beta1
       // since we are using Flux 2.1
-      "matchPackageNames": ["ImageUpdateAutomation"],
+      "matchDepNames": ["ImageUpdateAutomation"],
       "allowedVersions":  "image.toolkit.fluxcd.io/v1beta1",
     },
     {
       // Prevent updating HelmRepository from source.toolkit.fluxcd.io/v1beta2
       // since we are using Flux 2.1
-      "matchPackageNames": ["HelmRepository"],
+      "matchDepNames": ["HelmRepository"],
       "allowedVersions":  "source.toolkit.fluxcd.io/v1beta2",
     },
   ],

--- a/lang-go.json5
+++ b/lang-go.json5
@@ -1,38 +1,38 @@
 {
   "packageRules": [
     {
-      "matchPackagePatterns": [".*giantswarm.*"],
+      "matchDepPatterns": [".*giantswarm.*"],
       "groupName": "Giant Swarm Go modules",
       "matchManagers": ["gomod"]
     },
     {
-      "matchPackagePatterns": ["github.com/onsi/*"],
+      "matchDepPatterns": ["github.com/onsi/*"],
       "groupName": "test libraries"
     },
     {
-      "matchPackagePatterns": ["github.com/aws/aws-sdk-go*"],
+      "matchDepPatterns": ["github.com/aws/aws-sdk-go*"],
       "groupName": "aws sdk"
     },
     {
-      "matchPackagePatterns": ["^k8s.io"],
+      "matchDepPatterns": ["^k8s.io"],
       "groupName": "k8s modules",
       "allowedVersions": "< 0.21.0"
     },
     {
-      "matchPackagePatterns": ["^sigs.k8s.io"],
+      "matchDepPatterns": ["^sigs.k8s.io"],
       "groupName": "sig k8s modules"
     },
     {
-      "matchPackagePatterns": ["^sigs.k8s.io/cluster*"],
+      "matchDepPatterns": ["^sigs.k8s.io/cluster*"],
       "groupName": "capi modules",
       "enabled": false
     },
     {
-      "matchPackageNames": ["sigs.k8s.io/controller-runtime"],
+      "matchDepNames": ["sigs.k8s.io/controller-runtime"],
       "allowedVersions": "< 0.7.0"
     },
     {
-      "matchPackagePatterns": ["^github.com/giantswarm/apiextensions*"],
+      "matchDepPatterns": ["^github.com/giantswarm/apiextensions*"],
       "allowedVersions": ">= 4.0.0"
     },
     {


### PR DESCRIPTION
Currently Renovate logs warnings like these wherever it encounters `matchPackageNames` or `matchPackagePatterns`.

As far as I understand, the broader context is this issue: https://github.com/renovatebot/renovate/issues/16012

This PR changes config to use `matchDepNames` and `matchDepPatterns` instead.