### PR TITLE
Remove grouping of giantswarm Go modules

### DIFF
--- a/lang-go.json5
+++ b/lang-go.json5
@@ -1,11 +1,6 @@
 {
   "packageRules": [
     {
-      "matchDepPatterns": [".*giantswarm.*"],
-      "groupName": "Giant Swarm Go modules",
-      "matchManagers": ["gomod"]
-    },
-    {
       "matchDepPatterns": ["github.com/onsi/*"],
       "groupName": "test libraries"
     },


### PR DESCRIPTION
So far, all updates for Go modules from Giant Swarm were grouped into one PR per repository.

The problem with that is that it decreases the likelihood of the Renovate PR passing checks. A single library with incompatibilities will prevent all other upgrades.

There is no logical reason to group Go module upgrades from Giant Swarm, as all these libraries are mostly independent.

This PR removes the grouping.