### PR TITLE
Add support for dockerfile image repo regex updates.

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -108,6 +108,7 @@
         "repo: (?<depName>.*)\n(\\s*)default: \"?.+:v?(?<currentValue>.*?)(-debug)?\"?\n",
         "repo: (?<depName>.*)\n(\\s*)image: \"?.+:v?(?<currentValue>.*?)\"?\n",
         "repo: (?<depName>.*)\n(\\s)*([\\w|_]+)release:(\\s)*v?(?<currentValue>.*?)(\\s)*\n",
+        "repo: (?<depName>.*)\nFROM .+?:(?<currentValue>[^\s]+)",
       ],
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^\"?v?(?<version>.*)\"?$"


### PR DESCRIPTION
This solves the below cases. 
```
# repo: giantswarm/private-repo
FROM gsoci.azurecr.io/giantswarm/private-repo:2.53.0 AS private-repo

# repo: giantswarm/private-repo2
FROM gsoci.azurecr.io/giantswarm/private-repo2:2.53.0
```
issue: https://github.com/giantswarm/giantswarm/issues/29737

