### PR TITLE
Ignore operatorkit v8 in Go updates

### DIFF
--- a/lang-go.json5
+++ b/lang-go.json5
@@ -37,5 +37,8 @@
       "automerge": true,
     },
   ],
+  "ignoreDeps": [
+    "github.com/giantswarm/operatorkit/v8", // Released by mistake, release got pulled back
+  ],
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
 }


### PR DESCRIPTION
The release got pulled back. https://github.com/giantswarm/operatorkit/pull/619