### PR TITLE
Group Team Tinkerers test framework modules

### DIFF
--- a/lang-go.json5
+++ b/lang-go.json5
@@ -5,6 +5,14 @@
       "groupName": "test libraries"
     },
     {
+      "matchDepNames": [
+        "github.com/giantswarm/clustertest",
+        "github.com/giantswarm/cluster-standup-teardown",
+        "github.com/giantswarm/apptest-framework",
+      ],
+      "groupName": "test framework"
+    },
+    {
       "matchDepPatterns": ["github.com/aws/aws-sdk-go*"],
       "groupName": "aws sdk"
     },


### PR DESCRIPTION
Often the framework modules are updated together (e.g. `clustertest` is updated and then its bumped within `cluster-standup-teardown`) so it would be useful to have these grouped as single PRs where possible to speed up releasing cluster-test-suites and similar.