### PR TITLE
Ignore "k8s.io/client.go" releases ending in "+incompatible"

### DIFF
--- a/lang-go.json5
+++ b/lang-go.json5
@@ -16,7 +16,7 @@
       "matchDepNames": [
         "k8s.io/client-go",
       ],
-      "allowedVersions": "!/v11\.0\.0+incompatible$/", // Retracted release
+      "allowedVersions": "!/.*+incompatible$/", // Retracted releases
     },
     {
       "matchDepPatterns": ["github.com/aws/aws-sdk-go*"],

--- a/lang-go.json5
+++ b/lang-go.json5
@@ -13,6 +13,12 @@
       "groupName": "test framework"
     },
     {
+      "matchDepNames": [
+        "k8s.io/client-go",
+      ],
+      "allowedVersions": "!/v11\.0\.0+incompatible$/", // Retracted release
+    },
+    {
       "matchDepPatterns": ["github.com/aws/aws-sdk-go*"],
       "groupName": "aws sdk"
     },


### PR DESCRIPTION
Release `v11.0.0+incompatible` has been retracted, yet Renovate tries to update to it, like in https://github.com/giantswarm/apptestctl/pull/442

According to https://github.com/kubernetes/client-go/issues/1352 there may be more than just `v11.0.0...` around, so I'm adding an ignore-rule that excludes everything ending in `+incompatible`.