### PR TITLE
Disable vendir manager

### DIFF
--- a/disable-vendir.json5
+++ b/disable-vendir.json5
@@ -1,0 +1,3 @@
+{
+  "vendir": { "enabled": false },
+}


### PR DESCRIPTION
### Description

The vendir manager doesn't take into account any custom integrations that we may have. For example: Updating Helm dependencies.

Since we already have custom automation for updating charts with Vendir, it makes sense for some teams to disable this manager.