### PR TITLE
Exclude Flux system manifests from Kubernetes manager

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -76,7 +76,11 @@
 
   // Supports updating both image versions and Kubernetes API versions (e.g. `apiVersion: apps/v1beta1`)
   "kubernetes": {
-    "fileMatch": ["\\.y[a]?ml$"]
+    "fileMatch": ["\\.y[a]?ml$"],
+    "ignorePaths": [
+      // Avoid updating individual deployments in Flux manifests, this is instead handled by the Flux manager
+      "(?:^|/)gotk-components\\.ya?ml$"
+    ]
   },
   "customDatasources": {
     "capa": {


### PR DESCRIPTION
Currently Renovate is opening PRs to update the container images within the Flux system manifest ([example](https://github.com/giantswarm/cicd-gitops/pull/135)) which causes problems if needs to be deployed with CRD changes too. This change ensures that this file is only handled by the Flux manager which will update everything once an overarching Flux release is made instead of the individual components.