### PR TITLE
Enable automerge for all patch upgrades

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -72,6 +72,12 @@
       "sourceUrl": "https://github.com/giantswarm/releases",
       "sourceDirectory": "sdk",
     },
+    {
+      "matchUpdateTypes": [
+        "patch",
+      ],
+      "automerge": true,
+    }
   ],
 
   // Supports updating both image versions and Kubernetes API versions (e.g. `apiVersion: apps/v1beta1`)


### PR DESCRIPTION
Enable automerge for all patch upgrades. We already have auto merge enabled for patch upgrades of Go dependencies, but I think we can do it for all upgrades.