### PR TITLE
Support shared-configs yaml template format

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -142,7 +142,7 @@
       // before the version string line
       "customType": "regex",
       "fileMatch": [
-        ".*y[a]?ml$",
+        ".*y[a]?ml(.template)?$",
         "Dockerfile$",
         "^Makefile\\..+\\.mk$",
       ],
@@ -166,7 +166,7 @@
       // before the version string line
       "customType": "regex",
       "fileMatch": [
-        ".*y[a]?ml$",
+        ".*y[a]?ml$(.template)?",
         "Dockerfile$",
         "^Makefile\\..+\\.mk$",
       ],


### PR DESCRIPTION
In shared configs, files are defined as such `configmap-values.yaml.template` which obviously does not work with the existing fileMatch