### PR TITLE
Add exclusion for helm v4

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -111,7 +111,7 @@
     },
     {
       "description": "Exclude helm packages with major version v4",
-      "matchDepNames": ["/\bhelm\b/"],
+      "matchDepNames": ["/\\bhelm\\b/"],
       "allowedVersions": "!/^v?4\\./"
     }
   ],


### PR DESCRIPTION
Currently we want to avoid upgrading to Helm v4 anywhere.