### PR TITLE
Add Renovate preset to disable helm-values dependencies

### DIFF
--- a/disable-helm-values.json5
+++ b/disable-helm-values.json5
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "helm-values": { "enabled": false },
+}


### PR DESCRIPTION
This PR:

- adds a preset to disable updating of helm-values dependencies.
