### PR TITLE
Add Renovate preset to disable helmv3 dependencies

### DIFF
--- a/disable-helmv3.json5
+++ b/disable-helmv3.json5
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "helmv3": { "enabled": false },
+}


### PR DESCRIPTION
This PR:

- adds a preset to disable updating of helmv3 dependencies.
