### PR TITLE
fix: use packageRules instead of ignorePaths in disable-upstream-charts preset

### DIFF
--- a/disable-upstream-charts.json5
+++ b/disable-upstream-charts.json5
@@ -1,4 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "ignorePaths": ["helm/*/charts/**"],
+  "packageRules": [
+    {
+      "matchFileNames": ["helm/*/charts/**"],
+      "enabled": false,
+    },
+  ],
 }


### PR DESCRIPTION
`ignorePaths` arrays are replaced (not merged) when Renovate resolves an `extends` chain. This means any preset with `ignorePaths` silently wipes out the exclusions defined by earlier presets — including `zz_generated.*` from `default.json5`.