### PR TITLE
feat: configure conventional commits

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -3,6 +3,11 @@
   "extends": [
     "config:recommended" // https://docs.renovatebot.com/presets-config/#configrecommended
   ],
+  // Force Conventional Commits style for PR titles and commit messages
+  // (e.g. "chore(deps): update dependency foo to v1.2.3").
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
   // The labels to add to the GitHub PRs
   "labels": ["dependencies", "renovate"],
   // The dependency dashboard is an issue created in the repo that tracks the


### PR DESCRIPTION
The goal of this PR is to make Renovate consistently create commit and PR titles that follow the [Conventional Commits](https://www.conventionalcommits.org/) standard. It has been doing it in some cases, but not consistently.