### PR TITLE
feat: let lang-go and lang-python extend default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 however this project does not use Semantic Versioning and there are no releases.
 Instead this file uses a date-based structure.
 
+## 2026-05-13
+
+### Changed
+
+- `lang-go` and `lang-python` now extend `default`, which means they inherit and override our default configuration.
+
 ## 2026-05-12
 
 ### Added

--- a/lang-go.json5
+++ b/lang-go.json5
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>giantswarm/renovate-presets:default.json5",
+  ],
   "packageRules": [
     {
       "groupName": "test libraries",

--- a/lang-python.json5
+++ b/lang-python.json5
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>giantswarm/renovate-presets:default.json5",
+  ],
   "packageRules": [
     {
       "matchUpdateTypes": ["patch", "pin", "digest"],


### PR DESCRIPTION
This way, a Go repository that only references lang-go still inherits the default configuration, which contains important rules. Same for Python.