### PR TITLE
chore(deps): pin GitHub Action digests fleet-wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 however this project does not use Semantic Versioning and there are no releases.
 Instead this file uses a date-based structure.
 
+## 2026-05-27
+
+### Changed
+
+- `helpers:pinGitHubActionDigestsToSemver` added to `extends` in `default.json5`. All hand-authored GitHub Actions in consuming repos will be pinned to commit SHAs by Renovate (tag-only pins are a supply-chain risk per CWE-829). `zz_generated.*` workflows are already in `ignorePaths` and are unaffected.
+
+### Removed
+
+- `actions/setup-go` from `ignoreDeps` so it is version-managed and digest-pinned alongside other actions.
+
 ## 2026-05-13
 
 ### Changed

--- a/default.json5
+++ b/default.json5
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended" // https://docs.renovatebot.com/presets-config/#configrecommended
+    "config:recommended", // https://docs.renovatebot.com/presets-config/#configrecommended
+    "helpers:pinGitHubActionDigestsToSemver" // pin all hand-authored GitHub Actions to commit SHAs
   ],
   // Force Conventional Commits style for PR titles and commit messages
   // (e.g. "chore(deps): update dependency foo to v1.2.3").
@@ -26,7 +27,6 @@
     ".github/workflows/pre_commit_*.yaml"
   ],
   "ignoreDeps": [
-    "actions/setup-go",
     "github.com/imdario/mergo",
     "zricethezav/gitleaks-action"
   ],


### PR DESCRIPTION
## Summary

- Adds `helpers:pinGitHubActionDigestsToSemver` to `extends` in `default.json5`. Renovate will rewrite tag-only `@vN` action references to `@<commit-sha> # vX.Y.Z` across all repos that extend this preset.
- Removes `actions/setup-go` from `ignoreDeps` so it is version-managed and digest-pinned alongside `actions/checkout`, `actions/cache`, etc.

`zz_generated.*` workflows are already excluded via `ignorePaths` and are unaffected.

## Impact

This is a fleet-wide change. On the next Renovate run, every repo extending `default.json5` will receive a "Pin dependencies" PR for its hand-authored workflows. Those PRs are low-risk (no behaviour change), but there will be a wave of them. The `prConcurrentLimit`/`prHourlyLimit` throttles in the preset limit the blast radius per repo.

Closes giantswarm/mcp-oauth#341 (upstream fix for supply-chain hardening tracked there).

@giantswarm/team-planeteers — heads-up on the fleet-wide wave of pin PRs.