### PR TITLE
feat: fold vendir manager into default, PyPI delay, rebase MC preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 however this project does not use Semantic Versioning and there are no releases.
 Instead this file uses a date-based structure.
 
+## Unreleased
+
+### Added
+
+- `default.json5` now includes a vendir `customManager` that tracks upstream refs annotated with `# renovate: datasource=... depName=...` in `vendir.yml` files. Only fires where the annotation is present; no-op everywhere else. A matching `packageRule` routes vendir updates through `prCreation: approval` on a `renovate/vendir/` branch prefix. Repos carrying an inline vendir manager can drop their local copy.
+- `lang-python.json5` now applies a 14-day `minimumReleaseAge` for PyPI dependencies, matching the existing npm supply-chain delay in `default.json5`.
+
+### Changed
+
+- `customer-management-clusters.json5` now extends `default.json5` instead of `config:recommended`. The previously inlined `labels`, `dependencyDashboard`, `ignorePaths`, `ignoreDeps`, and helm-values `customManager` are removed, as `default.json5` already provides equivalent or broader coverage. The weekly `schedule` is retained.
+- `renovate.json5` (the preset repo's own config) migrated from `config:recommended` to `default.json5`.
+
 ## 2026-05-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -33,6 +33,30 @@ Multiple presets can be specified and they build on top of each other.
 }
 ```
 
+## Available presets
+
+| Preset | Purpose |
+|--------|---------|
+| `default.json5` | Base config for all repos. Includes semantic commits, labels, dependency dashboard, ignorePaths/ignoreDeps, architect-orb automerge, CAPI release datasources, `repo:`/`registry:` regex managers for YAML/Dockerfile/Makefiles, vendir manager, and npm/vendir PR policies. |
+| `lang-go.json5` | Go-specific additions: groups k8s/CAPI/AWS SDK/test modules, `gomodTidy`, `gomodUpdateImportPaths`. Extends `default.json5`. |
+| `lang-python.json5` | Python-specific additions: automerge patch/pin/digest, 14-day PyPI release age delay. Extends `default.json5`. |
+| `flux.json5` | Enables the Flux manager for `gotk-components.yaml` files. |
+| `customer-management-clusters.json5` | Base config for customer management-cluster GitOps repos. Extends `default.json5` with a weekly Thursday schedule. |
+| `disable-ansible.json5` | Disables the Ansible manager. |
+| `disable-helm-values.json5` | Disables the helm-values manager. |
+| `disable-helmv3.json5` | Disables the helmv3 manager. |
+| `disable-kustomize.json5` | Disables the kustomize manager. |
+| `disable-upstream-charts.json5` | Disables updates for vendored charts under `helm/*/charts/`. |
+| `disable-vendir.json5` | Disables the vendir manager. |
+| `tests-e2e-app.json5` | Adds `/run app-test-suites` trigger note to PR bodies. |
+| `tests-e2e-app-cabbage.json5` | Like `tests-e2e-app` with additional ignores for Cilium/Envoy-Gateway synced paths. |
+
+> **vendir support:** `default.json5` includes a built-in vendir `customManager`. Repos with annotated `vendir.yml` files get automatic version tracking without any extra preset. Annotate each synced ref with:
+> ```yaml
+> # renovate: datasource=github-releases depName=org/repo
+>   ref: v1.2.3
+> ```
+
 ## Renovate documentation resources
 
 * [Shareable config preset](https://docs.renovatebot.com/config-presets/)

--- a/customer-management-clusters.json5
+++ b/customer-management-clusters.json5
@@ -1,36 +1,8 @@
 {
   '$schema': 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
-    'config:recommended',
-  ],
-  labels: [
-    'dependencies',
-    'renovate',
-  ],
-  dependencyDashboard: true,
-  ignorePaths: [
-    '.github/workflows/zz_generated.*',
-    '.github/workflows/codeql-analysis.yml',
-    '.github/workflows/pre_commit_*.yaml',
-  ],
-  ignoreDeps: [
-    'actions/setup-go',
-    'architect',
-    'github.com/imdario/mergo',
-    'zricethezav/gitleaks-action',
-  ],
-  customManagers: [
-    {
-      'customType': 'regex',
-      'managerFilePatterns': [
-        '/^helm\\/.+\\/values\\.yaml$/',
-      ],
-      'matchStrings': [
-        'repo: (?<depName>.*)\n(\\s)*version: (?<currentValue>.*?)\n'
-      ],
-      'datasourceTemplate': 'github-releases',
-      'extractVersionTemplate': '^v(?<version>.*)$',
-    }
+    // Base config - https://github.com/giantswarm/renovate-presets/blob/main/default.json5
+    'github>giantswarm/renovate-presets:default.json5',
   ],
   schedule: [
     'after 6am on thursday',

--- a/default.json5
+++ b/default.json5
@@ -124,6 +124,13 @@
       "description": "Wait 14 days after publication before updating npm (JS/TS) dependencies to avoid pulling in compromised or quickly-yanked releases.",
       "matchManagers": ["npm"],
       "minimumReleaseAge": "14 days"
+    },
+    {
+      // vendir.yml upstream refs are proxied through an approval gate so that
+      // changes to synced vendor content can be reviewed before a branch is created.
+      "matchFileNames": ["vendir.yml"],
+      "branchPrefix": "renovate/vendir/",
+      "prCreation": "approval"
     }
   ],
 
@@ -219,6 +226,16 @@
       "managerFilePatterns": ["/^Dockerfile$/"],
       "matchStrings": [
         "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG .+_VER=(?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+    },
+    {
+      // vendir.yml files use inline annotations to declare the datasource/dep.
+      // Only fires where the annotation comment is present — no-op elsewhere.
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)vendir\\.yml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\n]+?)(?: versioning=(?<versioning>[^\\s]+))?\\n\\s+ref: (?<currentValue>[^\\n]+)"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
     },

--- a/lang-python.json5
+++ b/lang-python.json5
@@ -7,6 +7,11 @@
     {
       "matchUpdateTypes": ["patch", "pin", "digest"],
       "automerge": true
+    },
+    {
+      "description": "Wait 14 days after publication before updating PyPI (Python) dependencies to avoid pulling in compromised or quickly-yanked releases.",
+      "matchDatasources": ["pypi"],
+      "minimumReleaseAge": "14 days"
     }
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
+    "github>giantswarm/renovate-presets:default.json5",
   ],
 }


### PR DESCRIPTION
## What changed

**`default.json5`** — vendir upstream tracking is now built-in. Repos with `vendir.yml` files annotated with `# renovate: datasource=... depName=...` get automatic version PRs routed through an approval gate (`prCreation: approval`, `branchPrefix: renovate/vendir/`). The customManager is self-gating and is a no-op where no annotation is present. Repos currently carrying an inline vendir manager can drop their local copy once this lands.

**`lang-python.json5`** — 14-day `minimumReleaseAge` for the `pypi` datasource, matching the existing npm supply-chain delay in `default.json5`.

**`customer-management-clusters.json5`** — rebased from `config:recommended` onto `default.json5`. The previously inlined `labels`, `dependencyDashboard`, `ignorePaths`, `ignoreDeps`, and helm-values `customManager` are removed; `default.json5` provides equivalent or broader coverage for all of them. The weekly Thursday `schedule` is kept.

**`renovate.json5`** (this repo) — dogfoods `default.json5` instead of `config:recommended`.

## Adoption notes

Changes to `default.json5` and `lang-python.json5` propagate fleet-wide immediately (Renovate fetches presets at runtime). No per-repo regen needed.

The `customer-management-clusters.json5` rebase is a behavior change for customer MC repos: they now also inherit default's CAPI release datasources, the `kubernetes` manager, and architect-orb automerge. This is intentional — validate against one live MC repo before merging.

## Follow-up (separate PRs, non-blocking)

- Drop inline vendir managers from ~8 app repos (kyverno-{app,crds,policies}, trivy-{app,operator-app}, falco-app, cloudnative-pg-app, kubescape-app, teleport-kube-agent-app).
- Migrate `config:recommended`-direct repos onto `default.json5` (dex-operator, wepa-management-clusters, app-build-suite, others).
- Modernize deprecated `regexManagers`/`fileMatch` → `customManagers`/`managerFilePatterns` across ~10 repos.