### PR TITLE
chore: disable digest pinning for giantswarm-owned actions

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -36,9 +36,10 @@
       "groupName": "Giant Swarm GitHub workflows",
       "description": "Group all Giant Swarm workflow updates together and allow auto-merging.",
       "matchDepNames": [
-        "giantswarm/github-workflows",
+        "/^giantswarm\//"
       ],
-      "automerge": true
+      "automerge": true,
+      "pinDigests": false
     },
     {
       // Create separate major releases for CAPA,CAPZ,CAPV and CAPVCD


### PR DESCRIPTION
`helpers:pinGitHubActionDigestsToSemver` pins all GitHub Actions to a commit SHA, which is the right default for third-party actions (supply-chain hardening). For GS-owned reusable workflows (`giantswarm/*`), pinning to a SHA generates noise PRs with no security benefit — we trust our own repos and want to track `main`.

Changes:
- Broaden `matchDepNames` from `giantswarm/github-workflows` to `/^giantswarm\//` to cover all GS-owned action repos
- Add `pinDigests: false` to opt out of SHA pinning for those deps