### PR TITLE
revert: disable digest pinning for giantswarm-owned actions

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -36,10 +36,9 @@
       "groupName": "Giant Swarm GitHub workflows",
       "description": "Group all Giant Swarm workflow updates together and allow auto-merging.",
       "matchDepNames": [
-        "/^giantswarm\//"
+        "giantswarm/github-workflows",
       ],
-      "automerge": true,
-      "pinDigests": false
+      "automerge": true
     },
     {
       // Create separate major releases for CAPA,CAPZ,CAPV and CAPVCD


### PR DESCRIPTION
Reverts giantswarm/renovate-presets#102

@QuentinBisson I'm reverting this because this made renovate to group the wrong deps (thus wrong titles) 

<img width="901" height="422" alt="image" src="https://github.com/user-attachments/assets/b3d1cfd5-5bb6-4fe3-b80d-905e091becb9" />

There you can see that the title is for workflows but the deps are not related to workflows