### PR TITLE
chore: disable digest pinning for giantswarm-owned actions

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -41,6 +41,12 @@
       "automerge": true
     },
     {
+      "description": "Skip SHA pinning for Giant Swarm-owned GitHub Actions; we trust our own repos.",
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["/^giantswarm\\//"],
+      "pinDigests": false
+    },
+    {
       // Create separate major releases for CAPA,CAPZ,CAPV and CAPVCD
       "matchDepNames": ["capa", "capz", "capv", "capvcd"],
       "separateMajorMinor": true,


### PR DESCRIPTION
Re-lands #102 (reverted in #103).

The previous attempt broadened the existing "Giant Swarm GitHub workflows" rule from `giantswarm/github-workflows` to `/^giantswarm\//` and added `pinDigests: false` in-place. Because the same rule still carried `groupName: "Giant Swarm GitHub workflows"` and `automerge: true`, Renovate started lumping every `giantswarm/*` dep (Helm charts, container images, Go modules) under the workflows group title and flagging them for automerge. That is the breakage Matías screenshotted in #103.

This PR keeps the grouping rule untouched and adds a **separate** rule that:

- scopes the regex to `matchManagers: ["github-actions"]` so non-action deps are not matched,
- sets only `pinDigests: false` (no `groupName`, no `automerge`).

Note: `pinDigests: false` only stops Renovate from *adding* a digest. Workflow files that already pin `giantswarm/foo@<sha>` will keep that SHA until the ref is rewritten to a tag/branch in-repo.