### PR TITLE
feat: match `VERSION` in addition to `VER` in Dockerfile `ARG`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Instead this file uses a date-based structure.
 
 ## Unreleased
 
+### Changed
+
+- The Dockerfile `# renovate: datasource=... depName=...` annotation manager in `default.json5` now matches `ARG` names ending in `_VERSION` in addition to `_VER`.
+
 ## 2026-05-27
 
 ### Added

--- a/default.json5
+++ b/default.json5
@@ -231,7 +231,7 @@
       "customType": "regex",
       "managerFilePatterns": ["/^Dockerfile$/"],
       "matchStrings": [
-        "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG .+_VER=(?<currentValue>.*)\\s"
+        "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG .+_VER(?:SION)?=(?<currentValue>.*)\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
     },


### PR DESCRIPTION
The custom regex matcher for other data sources only matches `_VER` and not `_VERSION` in lines like `TOOLNAME_VER` which makes renovate ignore updating those dependencies, even if they are annotated.

This extends the match to `_VERSION`