### PR TITLE
feat: Set renovate to run only on weekends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Instead this file uses a date-based structure.
 
 ## Unreleased
 
+### Changed
+
+- Set renovate to run only on weekends
+
 ## 2026-05-27
 
 ### Added

--- a/default.json5
+++ b/default.json5
@@ -6,7 +6,7 @@
   ],
 
   // Run renovate only during weekends.
-  "schedule": ["* * * * 0,6"]
+  "schedule": ["* * * * 0,6"],
 
   // Force Conventional Commits style for PR titles and commit messages
   // (e.g. "chore(deps): update dependency foo to v1.2.3").

--- a/default.json5
+++ b/default.json5
@@ -4,6 +4,10 @@
     "config:recommended", // https://docs.renovatebot.com/presets-config/#configrecommended
     "helpers:pinGitHubActionDigestsToSemver" // pin all hand-authored GitHub Actions to commit SHAs
   ],
+
+  // Run renovate only during weekends.
+  "schedule": ["* * * * 0,6"]
+
   // Force Conventional Commits style for PR titles and commit messages
   // (e.g. "chore(deps): update dependency foo to v1.2.3").
   "semanticCommits": "enabled",


### PR DESCRIPTION
In order to reduce renovate noise I suggest to change renovate schedule so it only runs on weekends. [docs.renovatebot.com/configuration-options/#schedule](https://docs.renovatebot.com/configuration-options/#schedule)

According to the documentation this only limit the PR creation to happen during weekend, but other update/rebase actions should continue to work as usual.

> This defaults to true, meaning that Renovate will perform certain "desirable" updates to existing PRs even when outside of schedule. If you wish to disable all updates outside of scheduled hours then configure this field to false.

[https://docs.renovatebot.com/configuration-options/#schedule](https://docs.renovatebot.com/configuration-options/#updatenotscheduled)