### PR TITLE
fix(default): extend Dockerfile fileMatch to cover Dockerfile.<ext> variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Instead this file uses a date-based structure.
 ### Changed
 
 - The Dockerfile `# renovate: datasource=... depName=...` annotation manager in `default.json5` now matches `ARG` names ending in `_VERSION` in addition to `_VER`.
+- All three Dockerfile `managerFilePatterns` in `default.json5` now match `Dockerfile` and `Dockerfile.<ext>` (e.g. `Dockerfile.debian`, `Dockerfile.alpine`). Previously only the bare `Dockerfile` filename was scanned.
 
 ## 2026-05-27
 

--- a/default.json5
+++ b/default.json5
@@ -184,7 +184,7 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/.*y[a]?ml(.template)?$/",
-        "/Dockerfile$/",
+        "/Dockerfile(\\.\\w+)?$/",
         "/^Makefile\\..+\\.mk$/",
       ],
       "matchStrings": [
@@ -207,7 +207,7 @@
       "managerFilePatterns": [
         "/.*y[a]?ml$(.template)?/",
         "/.*sh$/",
-        "/Dockerfile$/",
+        "/Dockerfile(\\.\\w+)?$/",
         "/^Makefile\\..+\\.mk$/",
       ],
       "matchStrings": [
@@ -229,7 +229,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^Dockerfile$/"],
+      "managerFilePatterns": ["/^Dockerfile(\\.\\w+)?$/"],
       "matchStrings": [
         "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG .+_VER(?:SION)?=(?<currentValue>.*)\\s"
       ],


### PR DESCRIPTION
## What

All three `managerFilePatterns` entries that reference Dockerfiles in `default.json5` previously matched only the bare `Dockerfile` filename. Files like `Dockerfile.debian` or `Dockerfile.alpine` were silently skipped, so any `# renovate: datasource=... depName=...` annotations in those files were never processed.

Changed `"/Dockerfile$/"` → `"/Dockerfile(\\.\\w+)?$/"` and `"/^Dockerfile$/"` → `"/^Dockerfile(\\.\\w+)?$/"` across all three custom managers (docker datasource, github-releases datasource, inline-annotation).

## Why

Discovered via `giantswarm/klaus` where `Dockerfile.debian` is generated from `Dockerfile` and carries the same `renovate:` annotation. Renovate bumped `Dockerfile` but not `Dockerfile.debian`, causing the `git diff --exit-code Dockerfile.debian` CI check to fail on every dependency update PR.