### PR TITLE
feat(circleci): track codecov orb versions and automerge patch/minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Instead this file uses a date-based structure.
 ### Changed
 
 - The Dockerfile `# renovate: datasource=... depName=...` annotation manager in `default.json5` now matches `ARG` names ending in `_VERSION` in addition to `_VER`.
+- All three Dockerfile `managerFilePatterns` in `default.json5` now match `Dockerfile` and `Dockerfile.<ext>` (e.g. `Dockerfile.debian`, `Dockerfile.alpine`). Previously only the bare `Dockerfile` filename was scanned.
 
 ## 2026-05-27
 

--- a/default.json5
+++ b/default.json5
@@ -104,6 +104,19 @@
       "automerge": true
     },
     {
+      "description": "Allow Renovate to lookup the changelog for codecov CircleCI orb updates",
+      "matchManagers": ["circleci"],
+      "matchPackageNames": ["codecov/codecov"],
+      "sourceUrl": "https://github.com/codecov/codecov-circleci-orb"
+    },
+    {
+      "description": "Automerge patch & minor updates for codecov CircleCI orb",
+      "matchManagers": ["circleci"],
+      "matchPackageNames": ["codecov/codecov"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true
+    },
+    {
       // Allow renovate to lookup the changelog for aws-cli
       "matchDepNames": ["amazon/aws-cli"],
       "sourceUrl": "https://github.com/aws/aws-cli",

--- a/default.json5
+++ b/default.json5
@@ -184,7 +184,7 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/.*y[a]?ml(.template)?$/",
-        "/Dockerfile$/",
+        "/Dockerfile(\\.\\w+)?$/",
         "/^Makefile\\..+\\.mk$/",
       ],
       "matchStrings": [
@@ -207,7 +207,7 @@
       "managerFilePatterns": [
         "/.*y[a]?ml$(.template)?/",
         "/.*sh$/",
-        "/Dockerfile$/",
+        "/Dockerfile(\\.\\w+)?$/",
         "/^Makefile\\..+\\.mk$/",
       ],
       "matchStrings": [
@@ -229,7 +229,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^Dockerfile$/"],
+      "managerFilePatterns": ["/^Dockerfile(\\.\\w+)?$/"],
       "matchStrings": [
         "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG .+_VER(?:SION)?=(?<currentValue>.*)\\s"
       ],


### PR DESCRIPTION
The `codecov/codecov` CircleCI orb had no `packageRules` entry, so Renovate found the orb declaration in `.circleci/config.yml` but couldn't resolve changelog info or reliably track new releases against the CircleCI registry alone.

This caused `codecov/codecov@5.4.3` to go unnoticed across all GS repos after Codecov released v6.0.0 (the version that fixes the broken Keybase signing key), leading to a broken `(Codecov) Validate CLI` step in every affected pipeline.

Adds two rules modelled after the existing `architect` orb entries:
- `sourceUrl` pointing at the GitHub repo so Renovate can resolve changelogs and use GitHub releases as the version source
- automerge for patch and minor updates (major upgrades like v5→v6 stay as manual PRs, which is intentional)