### PR TITLE
feat: add deprecated.json5 preset for low-maintenance repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Instead this file uses a date-based structure.
 
 ## Unreleased
 
+### Added
+
+- `deprecated.json5` preset for deprecated / low-maintenance repos: disables all routine updates (major/minor/patch/pin/digest/bump) and keeps only security/vulnerability remediation. Meant to be extended alongside `default.json5`. The `giantswarm/github` align-files workflow applies it automatically to repos marked `lifecycle: deprecated` that have `gen.ci.generate`.
+
 ### Changed
 
 - The Dockerfile `# renovate: datasource=... depName=...` annotation manager in `default.json5` now matches `ARG` names ending in `_VERSION` in addition to `_VER`.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Multiple presets can be specified and they build on top of each other.
 | `lang-python.json5` | Python-specific additions: automerge patch/pin/digest, 14-day PyPI release age delay. Extends `default.json5`. |
 | `flux.json5` | Enables the Flux manager for `gotk-components.yaml` files. |
 | `customer-management-clusters.json5` | Base config for customer management-cluster GitOps repos. Extends `default.json5` with a weekly Thursday schedule. |
+| `deprecated.json5` | Deprecated / low-maintenance repos: disables all routine updates (major/minor/patch/pin/digest/bump) and keeps only security/vulnerability remediation. Extend in addition to `default.json5`. Applied automatically to repos marked `lifecycle: deprecated` with `gen.ci.generate` in `giantswarm/github`. |
 | `disable-ansible.json5` | Disables the Ansible manager. |
 | `disable-helm-values.json5` | Disables the helm-values manager. |
 | `disable-helmv3.json5` | Disables the helmv3 manager. |

--- a/deprecated.json5
+++ b/deprecated.json5
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  // Deprecated / low-maintenance repos: disable routine dependency updates and
+  // keep only security/vulnerability remediation. Avoids wasting effort
+  // rescuing bumps a repo on its way out will never benefit from, while still
+  // surfacing CVEs. Extend this in addition to default.json5; do not re-enable
+  // routine updates without removing the deprecation.
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest", "bump"],
+      "enabled": false,
+    },
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+  },
+}


### PR DESCRIPTION
## Summary

- Adds a `deprecated.json5` preset that disables all routine dependency updates (`major`/`minor`/`patch`/`pin`/`digest`/`bump`) and keeps only security/vulnerability remediation (`vulnerabilityAlerts.enabled: true`).
- Meant to be extended **in addition to** `default.json5`.
- Documents it in the README preset table and CHANGELOG.

## Why

Deprecated / low-maintenance repos (e.g. happa, being replaced by backstage) generate a constant stream of routine Renovate PRs that the repo will never benefit from, which then need rescuing through CI. This preset stops that noise at the source while still surfacing CVEs.

This is the single source of truth for the policy. The companion changes wire it up so that setting `lifecycle: deprecated` in `giantswarm/github` applies this preset automatically (via a new `devctl gen renovate --deprecated` flag) to repos whose Renovate config is regenerated by align-files.

## Test plan

- [x] `deprecated.json5` is valid JSON5
- [ ] Confirm a consuming repo's renovate run only opens `[security]` PRs after adopting the preset

Made with [Cursor](https://cursor.com)