### PR TITLE
feat: add tests-ats.json5 preset to disable Renovate for ATS Pipfiles

### DIFF
--- a/tests-ats.json5
+++ b/tests-ats.json5
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "ATS (app-test-suite) test deps are owned centrally in giantswarm/github (languages/python/Pipfile) and rolled out via align-files. Do not open per-repo update PRs (incl. vulnerability alerts for this test-only stack).",
+      "matchFileNames": ["**/ats/Pipfile", "**/ats/Pipfile.lock"],
+      "enabled": false,
+    },
+  ],
+}


### PR DESCRIPTION
## Summary

- Adds a standalone preset `tests-ats.json5` that disables Renovate for `**/ats/Pipfile` and `**/ats/Pipfile.lock`.
- The glob covers `tests/ats/`, bare `ats/` (happa), and `helm/<chart>/tests/ats/` (kyverno-policies).
- `default.json5` is intentionally **not** modified — this is a class-of-repo preset (cf. `disable-helm-values.json5`).

Part of the CI & build-system alignment epic (giantswarm/giantswarm#36729): the ATS test stack is being centralized in `giantswarm/github` (`languages/python/Pipfile`) and rolled out via align-files. This preset stops per-repo Renovate from fighting the align-managed file. It will be wired into the devctl-generated `renovate.json5` for generated-CI repos in a follow-up.

Closes #115

## Test plan

- [ ] Preset resolves as `github>giantswarm/renovate-presets:tests-ats.json5`.
- [ ] `default.json5` is unchanged.

Made with [Cursor](https://cursor.com)