### PR TITLE
feat: add lang-node.json5 preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Instead this file uses a date-based structure.
 
 ### Added
 
+- `lang-node.json5` preset for Node repos. Renovate's own `group:nodeJs` sets a `commitMessageTopic` but no `groupName`, so each place a repo pins Node gets a separate PR, all titled "update Node.js to vX" — and merging one alone splits the version CI runs from the version the image ships. This groups them into a single PR. Extended automatically by `devctl gen renovate` for `language: node` repos.
 - `deprecated.json5` preset for deprecated / low-maintenance repos: disables all routine updates (major/minor/patch/pin/digest/bump) and keeps only security/vulnerability remediation. Meant to be extended alongside `default.json5`. The `giantswarm/github` align-files workflow applies it automatically to repos marked `lifecycle: deprecated` that have `gen.ci.generate`.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Multiple presets can be specified and they build on top of each other.
 | `default.json5` | Base config for all repos. Includes semantic commits, labels, dependency dashboard, ignorePaths/ignoreDeps, architect-orb automerge, CAPI release datasources, `repo:`/`registry:` regex managers for YAML/Dockerfile/Makefiles, vendir manager, and npm/vendir PR policies. |
 | `lang-go.json5` | Go-specific additions: groups k8s/CAPI/AWS SDK/test modules, `gomodTidy`, `gomodUpdateImportPaths`. Extends `default.json5`. |
 | `lang-python.json5` | Python-specific additions: automerge patch/pin/digest, 14-day PyPI release age delay. Extends `default.json5`. |
+| `lang-node.json5` | Node-specific additions: groups every Node.js version pin (`.nvmrc`, a Dockerfile `FROM node:`, a `setup-node` step) into one PR, which Renovate's own `group:nodeJs` does not do. Extends `default.json5`. |
 | `flux.json5` | Enables the Flux manager for `gotk-components.yaml` files. |
 | `customer-management-clusters.json5` | Base config for customer management-cluster GitOps repos. Extends `default.json5` with a weekly Thursday schedule. |
 | `deprecated.json5` | Deprecated / low-maintenance repos: disables all routine updates (major/minor/patch/pin/digest/bump) and keeps only security/vulnerability remediation. Extend in addition to `default.json5`. Applied automatically to repos marked `lifecycle: deprecated` with `gen.ci.generate` in `giantswarm/github`. |

--- a/lang-node.json5
+++ b/lang-node.json5
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>giantswarm/renovate-presets:default.json5",
+  ],
+  "packageRules": [
+    {
+      // Renovate's own group:nodeJs (pulled in by config:recommended) sets a
+      // commitMessageTopic but no groupName, so every place a repo pins Node
+      // gets its own PR -- all titled "update Node.js to vX". A Node repo
+      // typically pins the same version two or three times (a .nvmrc, a
+      // Dockerfile `FROM node:`, a setup-node step), and merging one of those
+      // PRs alone splits the version CI runs from the version the image ships.
+      //
+      // Grouping them means one PR that moves every pin together. .nvmrc is the
+      // preferred pin: Renovate's built-in nvm manager owns it, setup-node
+      // reads it via node-version-file, and `devctl gen circleci` renders the
+      // CI executor image and its cache-key salt from it.
+      "description": "Move every Node.js version pin in one PR.",
+      "groupName": "Node.js",
+      "matchDatasources": ["docker", "node-version"],
+      "matchPackageNames": ["node"],
+    },
+  ],
+}


### PR DESCRIPTION
## What

A `lang-node.json5` preset, filling the gap next to the existing `lang-go.json5` and `lang-python.json5`. It contains one rule: group every Node.js version pin into a single PR.

`devctl gen renovate` will extend it for `language: node` repos — see the companion devctl PR.

## Why

Renovate's own `group:nodeJs` (pulled in by `config:recommended`) sets a `commitMessageTopic` but **no `groupName`**. So each place a repo pins Node gets its own PR, and they are all titled identically — "chore(deps): update node.js to vX.Y.Z" — while sitting on different branches.

A Node repo typically pins the same version two or three times: a `.nvmrc`, a Dockerfile `FROM node:`, a `setup-node` step. Merging one of those PRs alone splits the version CI runs from the version the image ships, and the identical titles make that easy to do by accident.

Found while fixing this in `giantswarm/backstage` (giantswarm/backstage#2062, giantswarm/devctl#2113). It is not repo-specific — it affects any repo with more than one Node pin.

## Scope

Three Giant Swarm repos are `language: node` today: `backstage`, `headlamp-cilium`, `headlamp-longhorn`. Small, but the rule is upstream-gap-shaped rather than repo-shaped, and the alternative is N copies of it.

## Testing

Validated with `renovate-config-validator`, then run for real — `renovate --platform=local --dry-run=full` against a scratch repo containing only a `.nvmrc`, a Dockerfile `FROM node:`, and a config extending this preset from this branch:

```
DEBUG: 2 flattened updates found: node, node
DEBUG: Returning 1 branch(es)
       branchName: renovate/node.js
```

Both pins in one branch. Without the preset they are two.

## Note on matching

`matchPackageNames: ["node"]` is an exact match, not upstream's `/(?:^|\/)node$/`. That deliberately excludes images like `calico/node` and `kindest/node` (which upstream has to special-case out) and `cimg/node`, whose handling for devctl-generated CI belongs in the generated `renovate.json5`, not here — a repo with hand-written CI should still get `cimg/node` bumps normally.