### PR TITLE
chore: state the lang-node rule's intent once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Instead this file uses a date-based structure.
 
 ### Changed
 
+- `lang-node.json5`: the rule's intent is stated once in its Renovate `description` field rather than a comment block.
 - The Dockerfile `# renovate: datasource=... depName=...` annotation manager in `default.json5` now matches `ARG` names ending in `_VERSION` in addition to `_VER`.
 - All three Dockerfile `managerFilePatterns` in `default.json5` now match `Dockerfile` and `Dockerfile.<ext>` (e.g. `Dockerfile.debian`, `Dockerfile.alpine`). Previously only the bare `Dockerfile` filename was scanned.
 - Include all tests in Cabbage rules

--- a/lang-node.json5
+++ b/lang-node.json5
@@ -5,18 +5,7 @@
   ],
   "packageRules": [
     {
-      // Renovate's own group:nodeJs (pulled in by config:recommended) sets a
-      // commitMessageTopic but no groupName, so every place a repo pins Node
-      // gets its own PR -- all titled "update Node.js to vX". A Node repo
-      // typically pins the same version two or three times (a .nvmrc, a
-      // Dockerfile `FROM node:`, a setup-node step), and merging one of those
-      // PRs alone splits the version CI runs from the version the image ships.
-      //
-      // Grouping them means one PR that moves every pin together. .nvmrc is the
-      // preferred pin: Renovate's built-in nvm manager owns it, setup-node
-      // reads it via node-version-file, and `devctl gen circleci` renders the
-      // CI executor image and its cache-key salt from it.
-      "description": "Move every Node.js version pin in one PR.",
+      "description": "Move every Node.js version pin (.nvmrc, a Dockerfile `FROM node:`, a setup-node step) in one PR, which Renovate's own group:nodeJs does not do.",
       "groupName": "Node.js",
       "matchDatasources": ["docker", "node-version"],
       "matchPackageNames": ["node"],


### PR DESCRIPTION
## What

Replaces the comment block in `lang-node.json5` with a single Renovate `description` field.

```diff
     {
-      // Renovate's own group:nodeJs (pulled in by config:recommended) sets a
-      // commitMessageTopic but no groupName, so every place a repo pins Node
-      // gets its own PR -- all titled "update Node.js to vX". A Node repo
-      // typically pins the same version two or three times (a .nvmrc, a
-      // Dockerfile `FROM node:`, a setup-node step), and merging one of those
-      // PRs alone splits the version CI runs from the version the image ships.
-      //
-      // Grouping them means one PR that moves every pin together. .nvmrc is the
-      // preferred pin: Renovate's built-in nvm manager owns it, setup-node
-      // reads it via node-version-file, and `devctl gen circleci` renders the
-      // CI executor image and its cache-key salt from it.
-      "description": "Move every Node.js version pin in one PR.",
+      "description": "Move every Node.js version pin (.nvmrc, a Dockerfile `FROM node:`, a setup-node step) in one PR, which Renovate's own group:nodeJs does not do.",
```

## Why

`description` is Renovate's own field for a rule's intent, and it surfaces in Renovate's output — so the comment block was a second, less useful copy. The full rationale lives in #124 and the CHANGELOG.

Companion to giantswarm/devctl#2116, which does the same for the rules devctl generates.

## Testing

`renovate-config-validator` passes. No behaviour change — only `description` text.